### PR TITLE
Use default python command line python for starting sqflint

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class Sqflint(PythonLinter):
     """Provides an interface to sqflint."""
 
     syntax = 'sqf'
-    cmd = 'sqflint@python3'
+    cmd = 'sqflint@python'
     regex = '\[(?P<line>\d+),(?P<column>\d+)\]:(?:(?P<error>error)|(?P<warning>warning|info)):(?P<message>.*\r?)'
     multiline = False
     line_col_base = (1, 1)


### PR DESCRIPTION
Sublime should find the correct one on systems that have `python` as Python 2, but I can't verify right now. This is what other SublimeLinter plugins do as well.