### PR TITLE
Fix cls.defaults errors

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,6 +16,6 @@ from SublimeLinter.lint import PythonLinter
 class Sqflint(PythonLinter):
     """Provides an interface to sqflint."""
 
-    syntax = 'sqf'
+    defaults = {'selector': 'source.sqf'}
     cmd = 'sqflint@python'
     regex = '\[(?P<line>\d+),(?P<column>\d+)\]:(?:(?P<error>error)|(?P<warning>warning|info)):(?P<message>.*\r?)'


### PR DESCRIPTION
sqflint: Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.
sqflint disabled. 'cls.defaults' is mandatory and MUST be a dict.